### PR TITLE
Fix null check error. Fix issue #9.

### DIFF
--- a/lib/screens/loginScreen.dart
+++ b/lib/screens/loginScreen.dart
@@ -46,7 +46,7 @@ class _LoginScreenState extends State<LoginScreen> {
     // check_url();
     _passwordVisible = false;
     // check if url and username are provided
-    if (url != "" && username != "") {
+    if (url != null && url != "" && username!= null && username != "") {
       _loading = true;
       logger.d("url: " + url!);
       logger.d("username: " + username!);


### PR DESCRIPTION
Checks for `null` values before using the `url` and `username` variables.