### PR TITLE
Refactor EPUB navigation: use jumpTo instead of gotoEpubCfi

### DIFF
--- a/lib/providers/fetchCategories.dart
+++ b/lib/providers/fetchCategories.dart
@@ -68,7 +68,7 @@ Future<(List<Entry>, List<Folder>)> getServerCategories({
   logger.d("got response");
   logger.d(response?.statusCode.toString());
   final data = response.data.items
-      .where((element) => element.collectionType == 'books')
+      .where((element) => element.collectionType == CollectionType.books)
       .toList();
 
   bool hasComics = true;

--- a/lib/screens/readingScreens/epubReader.dart
+++ b/lib/screens/readingScreens/epubReader.dart
@@ -202,6 +202,22 @@ class _EpubReaderState extends State<EpubReader> {
     });
   }
 
+  Future<void> onBookLoaded() async {
+    // Restore saved chapter index
+    final savedIndex = await loadChapterIndex();
+    if (savedIndex != null) {
+      logger.d("Restoring chapter index: $savedIndex");
+
+      // Wait for frame to fully load
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _epubController.jumpTo(index: savedIndex);
+      });
+    }
+
+    // Add other book loaded tasks here
+    logger.d("Book is fully loaded");
+  }
+
   Future<void> savePosition() async {
     Isar? isar = Isar.getInstance();
     if (isar != null) {
@@ -313,38 +329,15 @@ class _EpubReaderState extends State<EpubReader> {
                   onDocumentLoaded: (document) async {
                     logger.d("Document loaded: ${document.Title}");
 
-                    final savedIndex = await loadChapterIndex();
-                    if (savedIndex != null) {
-                      logger.d("Restoring chapter index: $savedIndex");
-                      Future.delayed(Duration(milliseconds: 500), () {
-                        _epubController.jumpTo(index: savedIndex);
-                      });
-                    }
+                    await onBookLoaded();
                   },
-                  // onDocumentLoaded: (document) {
-                  //   logger.d("Document loaded: ${document.Title}");
-                  //   // wait 5 seconds and then go to the chapter
-                  //   Future.delayed(Duration(seconds: 5), () {
-                  //     logger.d("Document loaded: ${document.Title}");
-                  //     goToChapter(_epubController);
-                  //   });
-                  //   // goToChapter(_epubController);
-                  // },
                   onChapterChanged: (chapterValue) {
                     final index = chapterValue?.position.index;
                     if (index != null) {
                       logger.d("Saving chapter index: $index");
                       saveChapterIndex(index);
                     }
-                  }
-                  // onChapterChanged: (chapter) {
-                  //   // only do it every 5th time
-                  //
-                  //   // logger.d("Chapter changed: $chapter");
-                  //   // logger.d(chapter!.position);
-                  //   updateChapter(_epubController.generateEpubCfi() ?? "error");
-                  // },
-                  ),
+                  }),
             );
           } else {
             return Scaffold(


### PR DESCRIPTION
### Problem:
- The existing `gotoEpubCfi` approach didn't reliably jump to the saved position in my testing.

### Solution:
- Refactored to save the chapter index instead and use `jumpTo(index)` to restore the last read position.
- This works consistently in my tests and preserves the "resume where you left off" functionality.

### Notes:
- I wasn't able to make `gotoEpubCfi` work reliably, so this is an alternative approach.
- Happy to adjust if maintainers prefer another method.

Also fixes issue #203. 
