### PR TITLE
Add sort functionality to search and collection screens

### DIFF
--- a/lib/models/entry.dart
+++ b/lib/models/entry.dart
@@ -39,17 +39,14 @@ class Entry {
 
   // Used to sort entries
   String sortName;
-  double communityRating = 0.0;
-  // critic rating missing or N/A for books
   String dateCreated = "";
-  String lastPlayedDate = "";
+  String lastPlayedDate = ""; //TODO: send to server
   String officialRating = "";
-  int playCount;
+  int playCount; //TODO: send to server
   String premiereDate = "";
   int runTimeTicks = 0;
   int indexNumber = 0;
   String seriesName;
-  // int productionYear = 0; //identical to releaseDate
 
   /// ComicInfoXML fields (for comics)
   String? writer;
@@ -83,7 +80,6 @@ class Entry {
     this.epubCfi = '',
     this.isFavorited = false,
     required this.sortName,
-    this.communityRating = 0.0,
     this.dateCreated = '',
     this.lastPlayedDate = '',
     this.officialRating = '',
@@ -130,7 +126,6 @@ class Entry {
       epubCfi: json['epubCfi'] ?? '',
       isFavorited: json['isFavorited'] ?? false,
       sortName: json['sortName'],
-      communityRating: json['communityRating'] ?? 0.0,
       dateCreated: json['dateCreated'] ?? '',
       lastPlayedDate: json['lastPlayedDate'] ?? '',
       officialRating: json['officialRating'] ?? '',
@@ -155,6 +150,6 @@ class Entry {
   // toString
   @override
   String toString() {
-    return 'Entry{\n\tid: $id,\n\ttitle: $title,\n\tdescription: $description,\n\timagePath: $imagePath,\n\treleaseDate: $releaseDate,\n\tdownloaded: $downloaded,\n\tpath: $path,\n\turl: $url,\n\ttags: $tags,\n\trating: $rating,\n\tprogress: $progress,\n\tpageNum: $pageNum,\n\tfolderPath: $folderPath,\n\tfilePath: $filePath,\n\ttype: $type,\n\tparentId: $parentId,\n\tepubCfi: $epubCfi,\n\tisFavorited: $isFavorited,\n\tsortName: $sortName,\n\tcommunityRating: $communityRating,\n\tdateCreated: $dateCreated,\n\tlastPlayedDate: $lastPlayedDate,\n\tofficialRating: $officialRating,\n\tplayCount: $playCount,\n\tpremiereDate: $premiereDate,\n\trunTimeTicks: $runTimeTicks,\n\tindexNumber: $indexNumber,\n\tseriesName: $seriesName,\n\twriter: $writer,\n\tpenciller: $penciller,\n\tinker: $inker,\n\tcolorist: $colorist,\n\tletterer: $letterer,\n\tcoverArtist: $coverArtist,\n\teditor: $editor,\n\ttranslator: $translator,\n\tpublisher: $publisher,\n\timprint: $imprint,\n}';
+    return 'Entry{\n\tid: $id,\n\ttitle: $title,\n\tdescription: $description,\n\timagePath: $imagePath,\n\treleaseDate: $releaseDate,\n\tdownloaded: $downloaded,\n\tpath: $path,\n\turl: $url,\n\ttags: $tags,\n\trating: $rating,\n\tprogress: $progress,\n\tpageNum: $pageNum,\n\tfolderPath: $folderPath,\n\tfilePath: $filePath,\n\ttype: $type,\n\tparentId: $parentId,\n\tepubCfi: $epubCfi,\n\tisFavorited: $isFavorited,\n\tsortName: $sortName,\n\tdateCreated: $dateCreated,\n\tlastPlayedDate: $lastPlayedDate,\n\tofficialRating: $officialRating,\n\tplayCount: $playCount,\n\tpremiereDate: $premiereDate,\n\trunTimeTicks: $runTimeTicks,\n\tindexNumber: $indexNumber,\n\tseriesName: $seriesName,\n\twriter: $writer,\n\tpenciller: $penciller,\n\tinker: $inker,\n\tcolorist: $colorist,\n\tletterer: $letterer,\n\tcoverArtist: $coverArtist,\n\teditor: $editor,\n\ttranslator: $translator,\n\tpublisher: $publisher,\n\timprint: $imprint,\n}';
   }
 }

--- a/lib/models/entry.dart
+++ b/lib/models/entry.dart
@@ -37,6 +37,20 @@ class Entry {
   String epubCfi = "";
   bool isFavorited = false;
 
+  // Used to sort entries
+  String sortName;
+  double communityRating = 0.0;
+  // critic rating missing or N/A for books
+  String dateCreated = "";
+  String lastPlayedDate = "";
+  String officialRating = "";
+  int playCount;
+  String premiereDate = "";
+  int runTimeTicks = 0;
+  int indexNumber = 0;
+  String seriesName;
+  // int productionYear = 0; //identical to releaseDate
+
   /// ComicInfoXML fields (for comics)
   String? writer;
   String? penciller;
@@ -68,6 +82,16 @@ class Entry {
     this.parentId = '',
     this.epubCfi = '',
     this.isFavorited = false,
+    required this.sortName,
+    this.communityRating = 0.0,
+    this.dateCreated = '',
+    this.lastPlayedDate = '',
+    this.officialRating = '',
+    required this.playCount,
+    this.premiereDate = '',
+    this.runTimeTicks = 0,
+    this.indexNumber = 0,
+    required this.seriesName,
     this.writer,
     this.penciller,
     this.inker,
@@ -105,6 +129,16 @@ class Entry {
       parentId: json['parentId'] ?? '',
       epubCfi: json['epubCfi'] ?? '',
       isFavorited: json['isFavorited'] ?? false,
+      sortName: json['sortName'],
+      communityRating: json['communityRating'] ?? 0.0,
+      dateCreated: json['dateCreated'] ?? '',
+      lastPlayedDate: json['lastPlayedDate'] ?? '',
+      officialRating: json['officialRating'] ?? '',
+      playCount: json['playCount'],
+      premiereDate: json['premiereDate'] ?? '',
+      runTimeTicks: json['runTimeTicks'] ?? 0,
+      indexNumber: json['indexNumber'] ?? 0,
+      seriesName: json['seriesName'],
       writer: json['writer'],
       penciller: json['penciller'],
       inker: json['inker'],
@@ -121,6 +155,6 @@ class Entry {
   // toString
   @override
   String toString() {
-    return 'Entry{\n\tid: $id,\n\ttitle: $title,\n\tdescription: $description,\n\timagePath: $imagePath,\n\treleaseDate: $releaseDate,\n\tdownloaded: $downloaded,\n\tpath: $path,\n\turl: $url,\n\ttags: $tags,\n\trating: $rating,\n\tprogress: $progress,\n\tpageNum: $pageNum,\n\tfolderPath: $folderPath,\n\tfilePath: $filePath,\n\ttype: $type,\n\tparentId: $parentId,\n\tepubCfi: $epubCfi,\n\tisFavorited: $isFavorited,\n\twriter: $writer,\n\tpenciller: $penciller,\n\tinker: $inker,\n\tcolorist: $colorist,\n\tletterer: $letterer,\n\tcoverArtist: $coverArtist,\n\teditor: $editor,\n\ttranslator: $translator,\n\tpublisher: $publisher,\n\timprint: $imprint,\n}';
+    return 'Entry{\n\tid: $id,\n\ttitle: $title,\n\tdescription: $description,\n\timagePath: $imagePath,\n\treleaseDate: $releaseDate,\n\tdownloaded: $downloaded,\n\tpath: $path,\n\turl: $url,\n\ttags: $tags,\n\trating: $rating,\n\tprogress: $progress,\n\tpageNum: $pageNum,\n\tfolderPath: $folderPath,\n\tfilePath: $filePath,\n\ttype: $type,\n\tparentId: $parentId,\n\tepubCfi: $epubCfi,\n\tisFavorited: $isFavorited,\n\tsortName: $sortName,\n\tcommunityRating: $communityRating,\n\tdateCreated: $dateCreated,\n\tlastPlayedDate: $lastPlayedDate,\n\tofficialRating: $officialRating,\n\tplayCount: $playCount,\n\tpremiereDate: $premiereDate,\n\trunTimeTicks: $runTimeTicks,\n\tindexNumber: $indexNumber,\n\tseriesName: $seriesName,\n\twriter: $writer,\n\tpenciller: $penciller,\n\tinker: $inker,\n\tcolorist: $colorist,\n\tletterer: $letterer,\n\tcoverArtist: $coverArtist,\n\teditor: $editor,\n\ttranslator: $translator,\n\tpublisher: $publisher,\n\timprint: $imprint,\n}';
   }
 }

--- a/lib/models/entry.dart
+++ b/lib/models/entry.dart
@@ -40,9 +40,9 @@ class Entry {
   // Used to sort entries
   String sortName;
   String dateCreated = "";
-  String lastPlayedDate = ""; //TODO: send to server
+  String lastPlayedDate = "";
   String officialRating = "";
-  int playCount; //TODO: send to server
+  int playCount;
   String premiereDate = "";
   int runTimeTicks = 0;
   int indexNumber = 0;

--- a/lib/models/entry.g.dart
+++ b/lib/models/entry.g.dart
@@ -22,189 +22,184 @@ const EntrySchema = CollectionSchema(
       name: r'colorist',
       type: IsarType.string,
     ),
-    r'communityRating': PropertySchema(
-      id: 1,
-      name: r'communityRating',
-      type: IsarType.double,
-    ),
     r'coverArtist': PropertySchema(
-      id: 2,
+      id: 1,
       name: r'coverArtist',
       type: IsarType.string,
     ),
     r'dateCreated': PropertySchema(
-      id: 3,
+      id: 2,
       name: r'dateCreated',
       type: IsarType.string,
     ),
     r'description': PropertySchema(
-      id: 4,
+      id: 3,
       name: r'description',
       type: IsarType.string,
     ),
     r'downloaded': PropertySchema(
-      id: 5,
+      id: 4,
       name: r'downloaded',
       type: IsarType.bool,
     ),
     r'editor': PropertySchema(
-      id: 6,
+      id: 5,
       name: r'editor',
       type: IsarType.string,
     ),
     r'epubCfi': PropertySchema(
-      id: 7,
+      id: 6,
       name: r'epubCfi',
       type: IsarType.string,
     ),
     r'filePath': PropertySchema(
-      id: 8,
+      id: 7,
       name: r'filePath',
       type: IsarType.string,
     ),
     r'folderPath': PropertySchema(
-      id: 9,
+      id: 8,
       name: r'folderPath',
       type: IsarType.string,
     ),
     r'id': PropertySchema(
-      id: 10,
+      id: 9,
       name: r'id',
       type: IsarType.string,
     ),
     r'imagePath': PropertySchema(
-      id: 11,
+      id: 10,
       name: r'imagePath',
       type: IsarType.string,
     ),
     r'imprint': PropertySchema(
-      id: 12,
+      id: 11,
       name: r'imprint',
       type: IsarType.string,
     ),
     r'indexNumber': PropertySchema(
-      id: 13,
+      id: 12,
       name: r'indexNumber',
       type: IsarType.long,
     ),
     r'inker': PropertySchema(
-      id: 14,
+      id: 13,
       name: r'inker',
       type: IsarType.string,
     ),
     r'isFavorited': PropertySchema(
-      id: 15,
+      id: 14,
       name: r'isFavorited',
       type: IsarType.bool,
     ),
     r'lastPlayedDate': PropertySchema(
-      id: 16,
+      id: 15,
       name: r'lastPlayedDate',
       type: IsarType.string,
     ),
     r'letterer': PropertySchema(
-      id: 17,
+      id: 16,
       name: r'letterer',
       type: IsarType.string,
     ),
     r'officialRating': PropertySchema(
-      id: 18,
+      id: 17,
       name: r'officialRating',
       type: IsarType.string,
     ),
     r'pageNum': PropertySchema(
-      id: 19,
+      id: 18,
       name: r'pageNum',
       type: IsarType.long,
     ),
     r'parentId': PropertySchema(
-      id: 20,
+      id: 19,
       name: r'parentId',
       type: IsarType.string,
     ),
     r'path': PropertySchema(
-      id: 21,
+      id: 20,
       name: r'path',
       type: IsarType.string,
     ),
     r'penciller': PropertySchema(
-      id: 22,
+      id: 21,
       name: r'penciller',
       type: IsarType.string,
     ),
     r'playCount': PropertySchema(
-      id: 23,
+      id: 22,
       name: r'playCount',
       type: IsarType.long,
     ),
     r'premiereDate': PropertySchema(
-      id: 24,
+      id: 23,
       name: r'premiereDate',
       type: IsarType.string,
     ),
     r'progress': PropertySchema(
-      id: 25,
+      id: 24,
       name: r'progress',
       type: IsarType.double,
     ),
     r'publisher': PropertySchema(
-      id: 26,
+      id: 25,
       name: r'publisher',
       type: IsarType.string,
     ),
     r'rating': PropertySchema(
-      id: 27,
+      id: 26,
       name: r'rating',
       type: IsarType.double,
     ),
     r'releaseDate': PropertySchema(
-      id: 28,
+      id: 27,
       name: r'releaseDate',
       type: IsarType.string,
     ),
     r'runTimeTicks': PropertySchema(
-      id: 29,
+      id: 28,
       name: r'runTimeTicks',
       type: IsarType.long,
     ),
     r'seriesName': PropertySchema(
-      id: 30,
+      id: 29,
       name: r'seriesName',
       type: IsarType.string,
     ),
     r'sortName': PropertySchema(
-      id: 31,
+      id: 30,
       name: r'sortName',
       type: IsarType.string,
     ),
     r'tags': PropertySchema(
-      id: 32,
+      id: 31,
       name: r'tags',
       type: IsarType.stringList,
     ),
     r'title': PropertySchema(
-      id: 33,
+      id: 32,
       name: r'title',
       type: IsarType.string,
     ),
     r'translator': PropertySchema(
-      id: 34,
+      id: 33,
       name: r'translator',
       type: IsarType.string,
     ),
     r'type': PropertySchema(
-      id: 35,
+      id: 34,
       name: r'type',
       type: IsarType.byte,
       enumMap: _EntrytypeEnumValueMap,
     ),
     r'url': PropertySchema(
-      id: 36,
+      id: 35,
       name: r'url',
       type: IsarType.string,
     ),
     r'writer': PropertySchema(
-      id: 37,
+      id: 36,
       name: r'writer',
       type: IsarType.string,
     )
@@ -337,43 +332,42 @@ void _entrySerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeString(offsets[0], object.colorist);
-  writer.writeDouble(offsets[1], object.communityRating);
-  writer.writeString(offsets[2], object.coverArtist);
-  writer.writeString(offsets[3], object.dateCreated);
-  writer.writeString(offsets[4], object.description);
-  writer.writeBool(offsets[5], object.downloaded);
-  writer.writeString(offsets[6], object.editor);
-  writer.writeString(offsets[7], object.epubCfi);
-  writer.writeString(offsets[8], object.filePath);
-  writer.writeString(offsets[9], object.folderPath);
-  writer.writeString(offsets[10], object.id);
-  writer.writeString(offsets[11], object.imagePath);
-  writer.writeString(offsets[12], object.imprint);
-  writer.writeLong(offsets[13], object.indexNumber);
-  writer.writeString(offsets[14], object.inker);
-  writer.writeBool(offsets[15], object.isFavorited);
-  writer.writeString(offsets[16], object.lastPlayedDate);
-  writer.writeString(offsets[17], object.letterer);
-  writer.writeString(offsets[18], object.officialRating);
-  writer.writeLong(offsets[19], object.pageNum);
-  writer.writeString(offsets[20], object.parentId);
-  writer.writeString(offsets[21], object.path);
-  writer.writeString(offsets[22], object.penciller);
-  writer.writeLong(offsets[23], object.playCount);
-  writer.writeString(offsets[24], object.premiereDate);
-  writer.writeDouble(offsets[25], object.progress);
-  writer.writeString(offsets[26], object.publisher);
-  writer.writeDouble(offsets[27], object.rating);
-  writer.writeString(offsets[28], object.releaseDate);
-  writer.writeLong(offsets[29], object.runTimeTicks);
-  writer.writeString(offsets[30], object.seriesName);
-  writer.writeString(offsets[31], object.sortName);
-  writer.writeStringList(offsets[32], object.tags);
-  writer.writeString(offsets[33], object.title);
-  writer.writeString(offsets[34], object.translator);
-  writer.writeByte(offsets[35], object.type.index);
-  writer.writeString(offsets[36], object.url);
-  writer.writeString(offsets[37], object.writer);
+  writer.writeString(offsets[1], object.coverArtist);
+  writer.writeString(offsets[2], object.dateCreated);
+  writer.writeString(offsets[3], object.description);
+  writer.writeBool(offsets[4], object.downloaded);
+  writer.writeString(offsets[5], object.editor);
+  writer.writeString(offsets[6], object.epubCfi);
+  writer.writeString(offsets[7], object.filePath);
+  writer.writeString(offsets[8], object.folderPath);
+  writer.writeString(offsets[9], object.id);
+  writer.writeString(offsets[10], object.imagePath);
+  writer.writeString(offsets[11], object.imprint);
+  writer.writeLong(offsets[12], object.indexNumber);
+  writer.writeString(offsets[13], object.inker);
+  writer.writeBool(offsets[14], object.isFavorited);
+  writer.writeString(offsets[15], object.lastPlayedDate);
+  writer.writeString(offsets[16], object.letterer);
+  writer.writeString(offsets[17], object.officialRating);
+  writer.writeLong(offsets[18], object.pageNum);
+  writer.writeString(offsets[19], object.parentId);
+  writer.writeString(offsets[20], object.path);
+  writer.writeString(offsets[21], object.penciller);
+  writer.writeLong(offsets[22], object.playCount);
+  writer.writeString(offsets[23], object.premiereDate);
+  writer.writeDouble(offsets[24], object.progress);
+  writer.writeString(offsets[25], object.publisher);
+  writer.writeDouble(offsets[26], object.rating);
+  writer.writeString(offsets[27], object.releaseDate);
+  writer.writeLong(offsets[28], object.runTimeTicks);
+  writer.writeString(offsets[29], object.seriesName);
+  writer.writeString(offsets[30], object.sortName);
+  writer.writeStringList(offsets[31], object.tags);
+  writer.writeString(offsets[32], object.title);
+  writer.writeString(offsets[33], object.translator);
+  writer.writeByte(offsets[34], object.type.index);
+  writer.writeString(offsets[35], object.url);
+  writer.writeString(offsets[36], object.writer);
 }
 
 Entry _entryDeserialize(
@@ -384,45 +378,44 @@ Entry _entryDeserialize(
 ) {
   final object = Entry(
     colorist: reader.readStringOrNull(offsets[0]),
-    communityRating: reader.readDoubleOrNull(offsets[1]) ?? 0.0,
-    coverArtist: reader.readStringOrNull(offsets[2]),
-    dateCreated: reader.readStringOrNull(offsets[3]) ?? '',
-    description: reader.readString(offsets[4]),
-    downloaded: reader.readBoolOrNull(offsets[5]) ?? false,
-    editor: reader.readStringOrNull(offsets[6]),
-    epubCfi: reader.readStringOrNull(offsets[7]) ?? '',
-    filePath: reader.readStringOrNull(offsets[8]) ?? '',
-    folderPath: reader.readStringOrNull(offsets[9]) ?? '',
-    id: reader.readString(offsets[10]),
-    imagePath: reader.readString(offsets[11]),
-    imprint: reader.readStringOrNull(offsets[12]),
-    indexNumber: reader.readLongOrNull(offsets[13]) ?? 0,
-    inker: reader.readStringOrNull(offsets[14]),
-    isFavorited: reader.readBoolOrNull(offsets[15]) ?? false,
+    coverArtist: reader.readStringOrNull(offsets[1]),
+    dateCreated: reader.readStringOrNull(offsets[2]) ?? '',
+    description: reader.readString(offsets[3]),
+    downloaded: reader.readBoolOrNull(offsets[4]) ?? false,
+    editor: reader.readStringOrNull(offsets[5]),
+    epubCfi: reader.readStringOrNull(offsets[6]) ?? '',
+    filePath: reader.readStringOrNull(offsets[7]) ?? '',
+    folderPath: reader.readStringOrNull(offsets[8]) ?? '',
+    id: reader.readString(offsets[9]),
+    imagePath: reader.readString(offsets[10]),
+    imprint: reader.readStringOrNull(offsets[11]),
+    indexNumber: reader.readLongOrNull(offsets[12]) ?? 0,
+    inker: reader.readStringOrNull(offsets[13]),
+    isFavorited: reader.readBoolOrNull(offsets[14]) ?? false,
     isarId: id,
-    lastPlayedDate: reader.readStringOrNull(offsets[16]) ?? '',
-    letterer: reader.readStringOrNull(offsets[17]),
-    officialRating: reader.readStringOrNull(offsets[18]) ?? '',
-    pageNum: reader.readLongOrNull(offsets[19]) ?? 0,
-    parentId: reader.readStringOrNull(offsets[20]) ?? '',
-    path: reader.readString(offsets[21]),
-    penciller: reader.readStringOrNull(offsets[22]),
-    playCount: reader.readLong(offsets[23]),
-    premiereDate: reader.readStringOrNull(offsets[24]) ?? '',
-    progress: reader.readDoubleOrNull(offsets[25]) ?? 0.0,
-    publisher: reader.readStringOrNull(offsets[26]),
-    rating: reader.readDouble(offsets[27]),
-    releaseDate: reader.readString(offsets[28]),
-    runTimeTicks: reader.readLongOrNull(offsets[29]) ?? 0,
-    seriesName: reader.readString(offsets[30]),
-    sortName: reader.readString(offsets[31]),
-    tags: reader.readStringList(offsets[32]) ?? [],
-    title: reader.readString(offsets[33]),
-    translator: reader.readStringOrNull(offsets[34]),
-    type: _EntrytypeValueEnumMap[reader.readByteOrNull(offsets[35])] ??
+    lastPlayedDate: reader.readStringOrNull(offsets[15]) ?? '',
+    letterer: reader.readStringOrNull(offsets[16]),
+    officialRating: reader.readStringOrNull(offsets[17]) ?? '',
+    pageNum: reader.readLongOrNull(offsets[18]) ?? 0,
+    parentId: reader.readStringOrNull(offsets[19]) ?? '',
+    path: reader.readString(offsets[20]),
+    penciller: reader.readStringOrNull(offsets[21]),
+    playCount: reader.readLong(offsets[22]),
+    premiereDate: reader.readStringOrNull(offsets[23]) ?? '',
+    progress: reader.readDoubleOrNull(offsets[24]) ?? 0.0,
+    publisher: reader.readStringOrNull(offsets[25]),
+    rating: reader.readDouble(offsets[26]),
+    releaseDate: reader.readString(offsets[27]),
+    runTimeTicks: reader.readLongOrNull(offsets[28]) ?? 0,
+    seriesName: reader.readString(offsets[29]),
+    sortName: reader.readString(offsets[30]),
+    tags: reader.readStringList(offsets[31]) ?? [],
+    title: reader.readString(offsets[32]),
+    translator: reader.readStringOrNull(offsets[33]),
+    type: _EntrytypeValueEnumMap[reader.readByteOrNull(offsets[34])] ??
         EntryType.book,
-    url: reader.readString(offsets[36]),
-    writer: reader.readStringOrNull(offsets[37]),
+    url: reader.readString(offsets[35]),
+    writer: reader.readStringOrNull(offsets[36]),
   );
   return object;
 }
@@ -437,79 +430,77 @@ P _entryDeserializeProp<P>(
     case 0:
       return (reader.readStringOrNull(offset)) as P;
     case 1:
-      return (reader.readDoubleOrNull(offset) ?? 0.0) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 2:
-      return (reader.readStringOrNull(offset)) as P;
-    case 3:
       return (reader.readStringOrNull(offset) ?? '') as P;
-    case 4:
+    case 3:
       return (reader.readString(offset)) as P;
-    case 5:
+    case 4:
       return (reader.readBoolOrNull(offset) ?? false) as P;
-    case 6:
+    case 5:
       return (reader.readStringOrNull(offset)) as P;
+    case 6:
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 7:
       return (reader.readStringOrNull(offset) ?? '') as P;
     case 8:
       return (reader.readStringOrNull(offset) ?? '') as P;
     case 9:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readString(offset)) as P;
     case 10:
       return (reader.readString(offset)) as P;
     case 11:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 12:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset) ?? 0) as P;
     case 13:
-      return (reader.readLongOrNull(offset) ?? 0) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 14:
-      return (reader.readStringOrNull(offset)) as P;
-    case 15:
       return (reader.readBoolOrNull(offset) ?? false) as P;
+    case 15:
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 16:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 17:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 18:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readLongOrNull(offset) ?? 0) as P;
     case 19:
-      return (reader.readLongOrNull(offset) ?? 0) as P;
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 20:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readString(offset)) as P;
     case 21:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 22:
-      return (reader.readStringOrNull(offset)) as P;
-    case 23:
       return (reader.readLong(offset)) as P;
-    case 24:
+    case 23:
       return (reader.readStringOrNull(offset) ?? '') as P;
-    case 25:
+    case 24:
       return (reader.readDoubleOrNull(offset) ?? 0.0) as P;
-    case 26:
+    case 25:
       return (reader.readStringOrNull(offset)) as P;
-    case 27:
+    case 26:
       return (reader.readDouble(offset)) as P;
-    case 28:
+    case 27:
       return (reader.readString(offset)) as P;
-    case 29:
+    case 28:
       return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 29:
+      return (reader.readString(offset)) as P;
     case 30:
       return (reader.readString(offset)) as P;
     case 31:
-      return (reader.readString(offset)) as P;
-    case 32:
       return (reader.readStringList(offset) ?? []) as P;
-    case 33:
+    case 32:
       return (reader.readString(offset)) as P;
-    case 34:
+    case 33:
       return (reader.readStringOrNull(offset)) as P;
-    case 35:
+    case 34:
       return (_EntrytypeValueEnumMap[reader.readByteOrNull(offset)] ??
           EntryType.book) as P;
-    case 36:
+    case 35:
       return (reader.readString(offset)) as P;
-    case 37:
+    case 36:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -802,68 +793,6 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'colorist',
         value: '',
-      ));
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingEqualTo(
-    double value, {
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'communityRating',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingGreaterThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'communityRating',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingLessThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'communityRating',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingBetween(
-    double lower,
-    double upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'communityRating',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-        epsilon: epsilon,
       ));
     });
   }
@@ -5072,18 +5001,6 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
     });
   }
 
-  QueryBuilder<Entry, Entry, QAfterSortBy> sortByCommunityRating() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'communityRating', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterSortBy> sortByCommunityRatingDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'communityRating', Sort.desc);
-    });
-  }
-
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByCoverArtist() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'coverArtist', Sort.asc);
@@ -5515,18 +5432,6 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByColoristDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'colorist', Sort.desc);
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterSortBy> thenByCommunityRating() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'communityRating', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Entry, Entry, QAfterSortBy> thenByCommunityRatingDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'communityRating', Sort.desc);
     });
   }
 
@@ -5971,12 +5876,6 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
     });
   }
 
-  QueryBuilder<Entry, Entry, QDistinct> distinctByCommunityRating() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'communityRating');
-    });
-  }
-
   QueryBuilder<Entry, Entry, QDistinct> distinctByCoverArtist(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -6232,12 +6131,6 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
   QueryBuilder<Entry, String?, QQueryOperations> coloristProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'colorist');
-    });
-  }
-
-  QueryBuilder<Entry, double, QQueryOperations> communityRatingProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'communityRating');
     });
   }
 

--- a/lib/models/entry.g.dart
+++ b/lib/models/entry.g.dart
@@ -22,139 +22,189 @@ const EntrySchema = CollectionSchema(
       name: r'colorist',
       type: IsarType.string,
     ),
-    r'coverArtist': PropertySchema(
+    r'communityRating': PropertySchema(
       id: 1,
+      name: r'communityRating',
+      type: IsarType.double,
+    ),
+    r'coverArtist': PropertySchema(
+      id: 2,
       name: r'coverArtist',
       type: IsarType.string,
     ),
+    r'dateCreated': PropertySchema(
+      id: 3,
+      name: r'dateCreated',
+      type: IsarType.string,
+    ),
     r'description': PropertySchema(
-      id: 2,
+      id: 4,
       name: r'description',
       type: IsarType.string,
     ),
     r'downloaded': PropertySchema(
-      id: 3,
+      id: 5,
       name: r'downloaded',
       type: IsarType.bool,
     ),
     r'editor': PropertySchema(
-      id: 4,
+      id: 6,
       name: r'editor',
       type: IsarType.string,
     ),
     r'epubCfi': PropertySchema(
-      id: 5,
+      id: 7,
       name: r'epubCfi',
       type: IsarType.string,
     ),
     r'filePath': PropertySchema(
-      id: 6,
+      id: 8,
       name: r'filePath',
       type: IsarType.string,
     ),
     r'folderPath': PropertySchema(
-      id: 7,
+      id: 9,
       name: r'folderPath',
       type: IsarType.string,
     ),
     r'id': PropertySchema(
-      id: 8,
+      id: 10,
       name: r'id',
       type: IsarType.string,
     ),
     r'imagePath': PropertySchema(
-      id: 9,
+      id: 11,
       name: r'imagePath',
       type: IsarType.string,
     ),
     r'imprint': PropertySchema(
-      id: 10,
+      id: 12,
       name: r'imprint',
       type: IsarType.string,
     ),
+    r'indexNumber': PropertySchema(
+      id: 13,
+      name: r'indexNumber',
+      type: IsarType.long,
+    ),
     r'inker': PropertySchema(
-      id: 11,
+      id: 14,
       name: r'inker',
       type: IsarType.string,
     ),
     r'isFavorited': PropertySchema(
-      id: 12,
+      id: 15,
       name: r'isFavorited',
       type: IsarType.bool,
     ),
+    r'lastPlayedDate': PropertySchema(
+      id: 16,
+      name: r'lastPlayedDate',
+      type: IsarType.string,
+    ),
     r'letterer': PropertySchema(
-      id: 13,
+      id: 17,
       name: r'letterer',
       type: IsarType.string,
     ),
+    r'officialRating': PropertySchema(
+      id: 18,
+      name: r'officialRating',
+      type: IsarType.string,
+    ),
     r'pageNum': PropertySchema(
-      id: 14,
+      id: 19,
       name: r'pageNum',
       type: IsarType.long,
     ),
     r'parentId': PropertySchema(
-      id: 15,
+      id: 20,
       name: r'parentId',
       type: IsarType.string,
     ),
     r'path': PropertySchema(
-      id: 16,
+      id: 21,
       name: r'path',
       type: IsarType.string,
     ),
     r'penciller': PropertySchema(
-      id: 17,
+      id: 22,
       name: r'penciller',
       type: IsarType.string,
     ),
+    r'playCount': PropertySchema(
+      id: 23,
+      name: r'playCount',
+      type: IsarType.long,
+    ),
+    r'premiereDate': PropertySchema(
+      id: 24,
+      name: r'premiereDate',
+      type: IsarType.string,
+    ),
     r'progress': PropertySchema(
-      id: 18,
+      id: 25,
       name: r'progress',
       type: IsarType.double,
     ),
     r'publisher': PropertySchema(
-      id: 19,
+      id: 26,
       name: r'publisher',
       type: IsarType.string,
     ),
     r'rating': PropertySchema(
-      id: 20,
+      id: 27,
       name: r'rating',
       type: IsarType.double,
     ),
     r'releaseDate': PropertySchema(
-      id: 21,
+      id: 28,
       name: r'releaseDate',
       type: IsarType.string,
     ),
+    r'runTimeTicks': PropertySchema(
+      id: 29,
+      name: r'runTimeTicks',
+      type: IsarType.long,
+    ),
+    r'seriesName': PropertySchema(
+      id: 30,
+      name: r'seriesName',
+      type: IsarType.string,
+    ),
+    r'sortName': PropertySchema(
+      id: 31,
+      name: r'sortName',
+      type: IsarType.string,
+    ),
     r'tags': PropertySchema(
-      id: 22,
+      id: 32,
       name: r'tags',
       type: IsarType.stringList,
     ),
     r'title': PropertySchema(
-      id: 23,
+      id: 33,
       name: r'title',
       type: IsarType.string,
     ),
     r'translator': PropertySchema(
-      id: 24,
+      id: 34,
       name: r'translator',
       type: IsarType.string,
     ),
     r'type': PropertySchema(
-      id: 25,
+      id: 35,
       name: r'type',
       type: IsarType.byte,
       enumMap: _EntrytypeEnumValueMap,
     ),
     r'url': PropertySchema(
-      id: 26,
+      id: 36,
       name: r'url',
       type: IsarType.string,
     ),
     r'writer': PropertySchema(
-      id: 27,
+      id: 37,
       name: r'writer',
       type: IsarType.string,
     )
@@ -205,6 +255,7 @@ int _entryEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  bytesCount += 3 + object.dateCreated.length * 3;
   bytesCount += 3 + object.description.length * 3;
   {
     final value = object.editor;
@@ -229,12 +280,14 @@ int _entryEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  bytesCount += 3 + object.lastPlayedDate.length * 3;
   {
     final value = object.letterer;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
     }
   }
+  bytesCount += 3 + object.officialRating.length * 3;
   bytesCount += 3 + object.parentId.length * 3;
   bytesCount += 3 + object.path.length * 3;
   {
@@ -243,6 +296,7 @@ int _entryEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  bytesCount += 3 + object.premiereDate.length * 3;
   {
     final value = object.publisher;
     if (value != null) {
@@ -250,6 +304,8 @@ int _entryEstimateSize(
     }
   }
   bytesCount += 3 + object.releaseDate.length * 3;
+  bytesCount += 3 + object.seriesName.length * 3;
+  bytesCount += 3 + object.sortName.length * 3;
   bytesCount += 3 + object.tags.length * 3;
   {
     for (var i = 0; i < object.tags.length; i++) {
@@ -281,33 +337,43 @@ void _entrySerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeString(offsets[0], object.colorist);
-  writer.writeString(offsets[1], object.coverArtist);
-  writer.writeString(offsets[2], object.description);
-  writer.writeBool(offsets[3], object.downloaded);
-  writer.writeString(offsets[4], object.editor);
-  writer.writeString(offsets[5], object.epubCfi);
-  writer.writeString(offsets[6], object.filePath);
-  writer.writeString(offsets[7], object.folderPath);
-  writer.writeString(offsets[8], object.id);
-  writer.writeString(offsets[9], object.imagePath);
-  writer.writeString(offsets[10], object.imprint);
-  writer.writeString(offsets[11], object.inker);
-  writer.writeBool(offsets[12], object.isFavorited);
-  writer.writeString(offsets[13], object.letterer);
-  writer.writeLong(offsets[14], object.pageNum);
-  writer.writeString(offsets[15], object.parentId);
-  writer.writeString(offsets[16], object.path);
-  writer.writeString(offsets[17], object.penciller);
-  writer.writeDouble(offsets[18], object.progress);
-  writer.writeString(offsets[19], object.publisher);
-  writer.writeDouble(offsets[20], object.rating);
-  writer.writeString(offsets[21], object.releaseDate);
-  writer.writeStringList(offsets[22], object.tags);
-  writer.writeString(offsets[23], object.title);
-  writer.writeString(offsets[24], object.translator);
-  writer.writeByte(offsets[25], object.type.index);
-  writer.writeString(offsets[26], object.url);
-  writer.writeString(offsets[27], object.writer);
+  writer.writeDouble(offsets[1], object.communityRating);
+  writer.writeString(offsets[2], object.coverArtist);
+  writer.writeString(offsets[3], object.dateCreated);
+  writer.writeString(offsets[4], object.description);
+  writer.writeBool(offsets[5], object.downloaded);
+  writer.writeString(offsets[6], object.editor);
+  writer.writeString(offsets[7], object.epubCfi);
+  writer.writeString(offsets[8], object.filePath);
+  writer.writeString(offsets[9], object.folderPath);
+  writer.writeString(offsets[10], object.id);
+  writer.writeString(offsets[11], object.imagePath);
+  writer.writeString(offsets[12], object.imprint);
+  writer.writeLong(offsets[13], object.indexNumber);
+  writer.writeString(offsets[14], object.inker);
+  writer.writeBool(offsets[15], object.isFavorited);
+  writer.writeString(offsets[16], object.lastPlayedDate);
+  writer.writeString(offsets[17], object.letterer);
+  writer.writeString(offsets[18], object.officialRating);
+  writer.writeLong(offsets[19], object.pageNum);
+  writer.writeString(offsets[20], object.parentId);
+  writer.writeString(offsets[21], object.path);
+  writer.writeString(offsets[22], object.penciller);
+  writer.writeLong(offsets[23], object.playCount);
+  writer.writeString(offsets[24], object.premiereDate);
+  writer.writeDouble(offsets[25], object.progress);
+  writer.writeString(offsets[26], object.publisher);
+  writer.writeDouble(offsets[27], object.rating);
+  writer.writeString(offsets[28], object.releaseDate);
+  writer.writeLong(offsets[29], object.runTimeTicks);
+  writer.writeString(offsets[30], object.seriesName);
+  writer.writeString(offsets[31], object.sortName);
+  writer.writeStringList(offsets[32], object.tags);
+  writer.writeString(offsets[33], object.title);
+  writer.writeString(offsets[34], object.translator);
+  writer.writeByte(offsets[35], object.type.index);
+  writer.writeString(offsets[36], object.url);
+  writer.writeString(offsets[37], object.writer);
 }
 
 Entry _entryDeserialize(
@@ -318,35 +384,45 @@ Entry _entryDeserialize(
 ) {
   final object = Entry(
     colorist: reader.readStringOrNull(offsets[0]),
-    coverArtist: reader.readStringOrNull(offsets[1]),
-    description: reader.readString(offsets[2]),
-    downloaded: reader.readBoolOrNull(offsets[3]) ?? false,
-    editor: reader.readStringOrNull(offsets[4]),
-    epubCfi: reader.readStringOrNull(offsets[5]) ?? '',
-    filePath: reader.readStringOrNull(offsets[6]) ?? '',
-    folderPath: reader.readStringOrNull(offsets[7]) ?? '',
-    id: reader.readString(offsets[8]),
-    imagePath: reader.readString(offsets[9]),
-    imprint: reader.readStringOrNull(offsets[10]),
-    inker: reader.readStringOrNull(offsets[11]),
-    isFavorited: reader.readBoolOrNull(offsets[12]) ?? false,
+    communityRating: reader.readDoubleOrNull(offsets[1]) ?? 0.0,
+    coverArtist: reader.readStringOrNull(offsets[2]),
+    dateCreated: reader.readStringOrNull(offsets[3]) ?? '',
+    description: reader.readString(offsets[4]),
+    downloaded: reader.readBoolOrNull(offsets[5]) ?? false,
+    editor: reader.readStringOrNull(offsets[6]),
+    epubCfi: reader.readStringOrNull(offsets[7]) ?? '',
+    filePath: reader.readStringOrNull(offsets[8]) ?? '',
+    folderPath: reader.readStringOrNull(offsets[9]) ?? '',
+    id: reader.readString(offsets[10]),
+    imagePath: reader.readString(offsets[11]),
+    imprint: reader.readStringOrNull(offsets[12]),
+    indexNumber: reader.readLongOrNull(offsets[13]) ?? 0,
+    inker: reader.readStringOrNull(offsets[14]),
+    isFavorited: reader.readBoolOrNull(offsets[15]) ?? false,
     isarId: id,
-    letterer: reader.readStringOrNull(offsets[13]),
-    pageNum: reader.readLongOrNull(offsets[14]) ?? 0,
-    parentId: reader.readStringOrNull(offsets[15]) ?? '',
-    path: reader.readString(offsets[16]),
-    penciller: reader.readStringOrNull(offsets[17]),
-    progress: reader.readDoubleOrNull(offsets[18]) ?? 0.0,
-    publisher: reader.readStringOrNull(offsets[19]),
-    rating: reader.readDouble(offsets[20]),
-    releaseDate: reader.readString(offsets[21]),
-    tags: reader.readStringList(offsets[22]) ?? [],
-    title: reader.readString(offsets[23]),
-    translator: reader.readStringOrNull(offsets[24]),
-    type: _EntrytypeValueEnumMap[reader.readByteOrNull(offsets[25])] ??
+    lastPlayedDate: reader.readStringOrNull(offsets[16]) ?? '',
+    letterer: reader.readStringOrNull(offsets[17]),
+    officialRating: reader.readStringOrNull(offsets[18]) ?? '',
+    pageNum: reader.readLongOrNull(offsets[19]) ?? 0,
+    parentId: reader.readStringOrNull(offsets[20]) ?? '',
+    path: reader.readString(offsets[21]),
+    penciller: reader.readStringOrNull(offsets[22]),
+    playCount: reader.readLong(offsets[23]),
+    premiereDate: reader.readStringOrNull(offsets[24]) ?? '',
+    progress: reader.readDoubleOrNull(offsets[25]) ?? 0.0,
+    publisher: reader.readStringOrNull(offsets[26]),
+    rating: reader.readDouble(offsets[27]),
+    releaseDate: reader.readString(offsets[28]),
+    runTimeTicks: reader.readLongOrNull(offsets[29]) ?? 0,
+    seriesName: reader.readString(offsets[30]),
+    sortName: reader.readString(offsets[31]),
+    tags: reader.readStringList(offsets[32]) ?? [],
+    title: reader.readString(offsets[33]),
+    translator: reader.readStringOrNull(offsets[34]),
+    type: _EntrytypeValueEnumMap[reader.readByteOrNull(offsets[35])] ??
         EntryType.book,
-    url: reader.readString(offsets[26]),
-    writer: reader.readStringOrNull(offsets[27]),
+    url: reader.readString(offsets[36]),
+    writer: reader.readStringOrNull(offsets[37]),
   );
   return object;
 }
@@ -361,59 +437,79 @@ P _entryDeserializeProp<P>(
     case 0:
       return (reader.readStringOrNull(offset)) as P;
     case 1:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset) ?? 0.0) as P;
     case 2:
-      return (reader.readString(offset)) as P;
-    case 3:
-      return (reader.readBoolOrNull(offset) ?? false) as P;
-    case 4:
       return (reader.readStringOrNull(offset)) as P;
+    case 3:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 4:
+      return (reader.readString(offset)) as P;
     case 5:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readBoolOrNull(offset) ?? false) as P;
     case 6:
-      return (reader.readStringOrNull(offset) ?? '') as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 7:
       return (reader.readStringOrNull(offset) ?? '') as P;
     case 8:
-      return (reader.readString(offset)) as P;
-    case 9:
-      return (reader.readString(offset)) as P;
-    case 10:
-      return (reader.readStringOrNull(offset)) as P;
-    case 11:
-      return (reader.readStringOrNull(offset)) as P;
-    case 12:
-      return (reader.readBoolOrNull(offset) ?? false) as P;
-    case 13:
-      return (reader.readStringOrNull(offset)) as P;
-    case 14:
-      return (reader.readLongOrNull(offset) ?? 0) as P;
-    case 15:
       return (reader.readStringOrNull(offset) ?? '') as P;
-    case 16:
+    case 9:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 10:
       return (reader.readString(offset)) as P;
+    case 11:
+      return (reader.readString(offset)) as P;
+    case 12:
+      return (reader.readStringOrNull(offset)) as P;
+    case 13:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 14:
+      return (reader.readStringOrNull(offset)) as P;
+    case 15:
+      return (reader.readBoolOrNull(offset) ?? false) as P;
+    case 16:
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 17:
       return (reader.readStringOrNull(offset)) as P;
     case 18:
-      return (reader.readDoubleOrNull(offset) ?? 0.0) as P;
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 19:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset) ?? 0) as P;
     case 20:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 21:
       return (reader.readString(offset)) as P;
     case 22:
-      return (reader.readStringList(offset) ?? []) as P;
-    case 23:
-      return (reader.readString(offset)) as P;
-    case 24:
       return (reader.readStringOrNull(offset)) as P;
+    case 23:
+      return (reader.readLong(offset)) as P;
+    case 24:
+      return (reader.readStringOrNull(offset) ?? '') as P;
     case 25:
+      return (reader.readDoubleOrNull(offset) ?? 0.0) as P;
+    case 26:
+      return (reader.readStringOrNull(offset)) as P;
+    case 27:
+      return (reader.readDouble(offset)) as P;
+    case 28:
+      return (reader.readString(offset)) as P;
+    case 29:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 30:
+      return (reader.readString(offset)) as P;
+    case 31:
+      return (reader.readString(offset)) as P;
+    case 32:
+      return (reader.readStringList(offset) ?? []) as P;
+    case 33:
+      return (reader.readString(offset)) as P;
+    case 34:
+      return (reader.readStringOrNull(offset)) as P;
+    case 35:
       return (_EntrytypeValueEnumMap[reader.readByteOrNull(offset)] ??
           EntryType.book) as P;
-    case 26:
+    case 36:
       return (reader.readString(offset)) as P;
-    case 27:
+    case 37:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -710,6 +806,68 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'communityRating',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'communityRating',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'communityRating',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> communityRatingBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'communityRating',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterFilterCondition> coverArtistIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -851,6 +1009,136 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'coverArtist',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'dateCreated',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'dateCreated',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'dateCreated',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'dateCreated',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> dateCreatedIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'dateCreated',
         value: '',
       ));
     });
@@ -1935,6 +2223,59 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> indexNumberEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'indexNumber',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> indexNumberGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'indexNumber',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> indexNumberLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'indexNumber',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> indexNumberBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'indexNumber',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterFilterCondition> inkerIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -2141,6 +2482,136 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lastPlayedDate',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'lastPlayedDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'lastPlayedDate',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastPlayedDate',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> lastPlayedDateIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'lastPlayedDate',
+        value: '',
+      ));
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterFilterCondition> lettererIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -2282,6 +2753,136 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'letterer',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'officialRating',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'officialRating',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'officialRating',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'officialRating',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> officialRatingIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'officialRating',
         value: '',
       ));
     });
@@ -2743,6 +3344,189 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> playCountEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'playCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> playCountGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'playCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> playCountLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'playCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> playCountBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'playCount',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'premiereDate',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'premiereDate',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'premiereDate',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'premiereDate',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> premiereDateIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'premiereDate',
+        value: '',
+      ));
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterFilterCondition> progressEqualTo(
     double value, {
     double epsilon = Query.epsilon,
@@ -3138,6 +3922,319 @@ extension EntryQueryFilter on QueryBuilder<Entry, Entry, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'releaseDate',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> runTimeTicksEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'runTimeTicks',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> runTimeTicksGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'runTimeTicks',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> runTimeTicksLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'runTimeTicks',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> runTimeTicksBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'runTimeTicks',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'seriesName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'seriesName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'seriesName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'seriesName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> seriesNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'seriesName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'sortName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'sortName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'sortName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterFilterCondition> sortNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'sortName',
         value: '',
       ));
     });
@@ -3975,6 +5072,18 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByCommunityRating() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'communityRating', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByCommunityRatingDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'communityRating', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByCoverArtist() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'coverArtist', Sort.asc);
@@ -3984,6 +5093,18 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByCoverArtistDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'coverArtist', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByDateCreated() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'dateCreated', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByDateCreatedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'dateCreated', Sort.desc);
     });
   }
 
@@ -4095,6 +5216,18 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByIndexNumber() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'indexNumber', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByIndexNumberDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'indexNumber', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByInker() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'inker', Sort.asc);
@@ -4119,6 +5252,18 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByLastPlayedDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastPlayedDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByLastPlayedDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastPlayedDate', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByLetterer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'letterer', Sort.asc);
@@ -4128,6 +5273,18 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByLettererDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'letterer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByOfficialRating() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'officialRating', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByOfficialRatingDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'officialRating', Sort.desc);
     });
   }
 
@@ -4179,6 +5336,30 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByPlayCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'playCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByPlayCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'playCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByPremiereDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'premiereDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByPremiereDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'premiereDate', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'progress', Sort.asc);
@@ -4224,6 +5405,42 @@ extension EntryQuerySortBy on QueryBuilder<Entry, Entry, QSortBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> sortByReleaseDateDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'releaseDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByRunTimeTicks() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'runTimeTicks', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortByRunTimeTicksDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'runTimeTicks', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortBySeriesName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'seriesName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortBySeriesNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'seriesName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortBySortName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sortName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> sortBySortNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sortName', Sort.desc);
     });
   }
 
@@ -4301,6 +5518,18 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByCommunityRating() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'communityRating', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByCommunityRatingDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'communityRating', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByCoverArtist() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'coverArtist', Sort.asc);
@@ -4310,6 +5539,18 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByCoverArtistDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'coverArtist', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByDateCreated() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'dateCreated', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByDateCreatedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'dateCreated', Sort.desc);
     });
   }
 
@@ -4421,6 +5662,18 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByIndexNumber() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'indexNumber', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByIndexNumberDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'indexNumber', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByInker() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'inker', Sort.asc);
@@ -4457,6 +5710,18 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByLastPlayedDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastPlayedDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByLastPlayedDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastPlayedDate', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByLetterer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'letterer', Sort.asc);
@@ -4466,6 +5731,18 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByLettererDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'letterer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByOfficialRating() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'officialRating', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByOfficialRatingDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'officialRating', Sort.desc);
     });
   }
 
@@ -4517,6 +5794,30 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByPlayCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'playCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByPlayCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'playCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByPremiereDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'premiereDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByPremiereDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'premiereDate', Sort.desc);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'progress', Sort.asc);
@@ -4562,6 +5863,42 @@ extension EntryQuerySortThenBy on QueryBuilder<Entry, Entry, QSortThenBy> {
   QueryBuilder<Entry, Entry, QAfterSortBy> thenByReleaseDateDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'releaseDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByRunTimeTicks() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'runTimeTicks', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenByRunTimeTicksDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'runTimeTicks', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenBySeriesName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'seriesName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenBySeriesNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'seriesName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenBySortName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sortName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QAfterSortBy> thenBySortNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sortName', Sort.desc);
     });
   }
 
@@ -4634,10 +5971,23 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QDistinct> distinctByCommunityRating() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'communityRating');
+    });
+  }
+
   QueryBuilder<Entry, Entry, QDistinct> distinctByCoverArtist(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'coverArtist', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctByDateCreated(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'dateCreated', caseSensitive: caseSensitive);
     });
   }
 
@@ -4703,6 +6053,12 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QDistinct> distinctByIndexNumber() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'indexNumber');
+    });
+  }
+
   QueryBuilder<Entry, Entry, QDistinct> distinctByInker(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -4716,10 +6072,26 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QDistinct> distinctByLastPlayedDate(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lastPlayedDate',
+          caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QDistinct> distinctByLetterer(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'letterer', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctByOfficialRating(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'officialRating',
+          caseSensitive: caseSensitive);
     });
   }
 
@@ -4750,6 +6122,19 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
     });
   }
 
+  QueryBuilder<Entry, Entry, QDistinct> distinctByPlayCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'playCount');
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctByPremiereDate(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'premiereDate', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Entry, Entry, QDistinct> distinctByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'progress');
@@ -4773,6 +6158,26 @@ extension EntryQueryWhereDistinct on QueryBuilder<Entry, Entry, QDistinct> {
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'releaseDate', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctByRunTimeTicks() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'runTimeTicks');
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctBySeriesName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'seriesName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Entry, Entry, QDistinct> distinctBySortName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'sortName', caseSensitive: caseSensitive);
     });
   }
 
@@ -4830,9 +6235,21 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Entry, double, QQueryOperations> communityRatingProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'communityRating');
+    });
+  }
+
   QueryBuilder<Entry, String?, QQueryOperations> coverArtistProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'coverArtist');
+    });
+  }
+
+  QueryBuilder<Entry, String, QQueryOperations> dateCreatedProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'dateCreated');
     });
   }
 
@@ -4890,6 +6307,12 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Entry, int, QQueryOperations> indexNumberProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'indexNumber');
+    });
+  }
+
   QueryBuilder<Entry, String?, QQueryOperations> inkerProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'inker');
@@ -4902,9 +6325,21 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Entry, String, QQueryOperations> lastPlayedDateProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lastPlayedDate');
+    });
+  }
+
   QueryBuilder<Entry, String?, QQueryOperations> lettererProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'letterer');
+    });
+  }
+
+  QueryBuilder<Entry, String, QQueryOperations> officialRatingProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'officialRating');
     });
   }
 
@@ -4932,6 +6367,18 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Entry, int, QQueryOperations> playCountProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'playCount');
+    });
+  }
+
+  QueryBuilder<Entry, String, QQueryOperations> premiereDateProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'premiereDate');
+    });
+  }
+
   QueryBuilder<Entry, double, QQueryOperations> progressProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'progress');
@@ -4953,6 +6400,24 @@ extension EntryQueryProperty on QueryBuilder<Entry, Entry, QQueryProperty> {
   QueryBuilder<Entry, String, QQueryOperations> releaseDateProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'releaseDate');
+    });
+  }
+
+  QueryBuilder<Entry, int, QQueryOperations> runTimeTicksProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'runTimeTicks');
+    });
+  }
+
+  QueryBuilder<Entry, String, QQueryOperations> seriesNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'seriesName');
+    });
+  }
+
+  QueryBuilder<Entry, String, QQueryOperations> sortNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'sortName');
     });
   }
 

--- a/lib/providers/fetchBooks.dart
+++ b/lib/providers/fetchBooks.dart
@@ -43,6 +43,7 @@ Future<void> getComics(String comicsId) async {
     ItemFields.tags,
     ItemFields.overview,
     ItemFields.parentId,
+    ItemFields.dateCreated,
   ]);
 
   // turn into built list
@@ -103,6 +104,16 @@ Future<void> getComics(String comicsId) async {
       tags: element.tags != null ? element.tags!.toList() : [],
       parentId: element.parentId ?? '',
       isFavorited: element.userData?.isFavorite ?? false,
+      sortName: (element.forcedSortName ?? element.sortName) ?? '',
+      communityRating: element.communityRating ?? 0.0,
+      dateCreated: element.dateCreated?.toIso8601String() ?? '',
+      lastPlayedDate: element.userData?.lastPlayedDate?.toIso8601String() ?? '',
+      officialRating: element.officialRating ?? '',
+      playCount: element.userData?.playCount ?? 0,
+      premiereDate: element.premiereDate?.toIso8601String() ?? '',
+      runTimeTicks: element.runTimeTicks ?? 0,
+      indexNumber: element.indexNumber ?? 0,
+      seriesName: element.seriesName ?? '',
       downloaded: false,
     );
     List<String> bookFileTypes = ['pdf', 'epub', 'mobi', 'azw3', 'kpf'];

--- a/lib/providers/fetchBooks.dart
+++ b/lib/providers/fetchBooks.dart
@@ -105,7 +105,6 @@ Future<void> getComics(String comicsId) async {
       parentId: element.parentId ?? '',
       isFavorited: element.userData?.isFavorite ?? false,
       sortName: (element.forcedSortName ?? element.sortName) ?? '',
-      communityRating: element.communityRating ?? 0.0,
       dateCreated: element.dateCreated?.toIso8601String() ?? '',
       lastPlayedDate: element.userData?.lastPlayedDate?.toIso8601String() ?? '',
       officialRating: element.officialRating ?? '',

--- a/lib/providers/updateLastPlayInfo.dart
+++ b/lib/providers/updateLastPlayInfo.dart
@@ -1,0 +1,54 @@
+// the purpose of this file is to update the play count and lastPlayedDate on jellyfin
+import 'package:tentacle/tentacle.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:package_info_plus/package_info_plus.dart' as p_info;
+import 'package:jellybook/variables.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> updateLastPlayInfo(String id, int playCount, String lastPlayedDate) async {
+  // update the entry on the server
+
+  p_info.PackageInfo packageInfo = await p_info.PackageInfo.fromPlatform();
+  final prefs = await SharedPreferences.getInstance();
+  final server = prefs.getString('server')!;
+  final userId = prefs.getString('UserId')!;
+  final token = prefs.getString('accessToken')!;
+  final version = packageInfo.version;
+  const _client = "JellyBook";
+  const _device = "Unknown Device";
+  const _deviceId = "Unknown Device id";
+
+  final UpdateUserItemDataDto updatedData = UpdateUserItemDataDto((UpdateUserItemDataDtoBuilder builder) {
+    builder.playCount = playCount;
+    builder.lastPlayedDate = DateTime.tryParse(lastPlayedDate)?.toUtc();
+  });
+
+  final headers = {
+    'Accept': 'application/json',
+    'Accept-Language': 'en-US,en;q=0.5',
+    'Accept-Encoding': 'gzip, deflate',
+    'Content-Type': 'application/json',
+    "X-Emby-Authorization":
+        "MediaBrowser Client=\"$_client\", Device=\"$_device\", DeviceId=\"$_deviceId\", Version=\"$version\", Token=\"$token\"",
+    'Connection': 'keep-alive',
+    'Origin': server,
+    'Host': server.substring(server.indexOf("//") + 2, server.length),
+    'Content-Length': '0',
+  };
+  final api = Tentacle(basePathOverride: server).getItemsApi();
+  try {
+    final response = await api.updateItemUserData(
+      userId: userId,
+      itemId: id,
+      headers: headers,
+      updateUserItemDataDto: updatedData,
+    );
+    logger.d(response.statusCode);
+    logger.d(response.realUri);
+  } catch (e, s) {
+    logger.e(e.toString());
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    bool useSentry = prefs.getBool('useSentry') ?? false;
+    if (useSentry) await Sentry.captureException(e, stackTrace: s);
+  }
+}

--- a/lib/screens/MainScreens/searchScreen.dart
+++ b/lib/screens/MainScreens/searchScreen.dart
@@ -36,7 +36,7 @@ class _SearchScreenState extends State<SearchScreen> {
   List<Entry> searchResults = [];
   // List<Map<String, dynamic>> searchResults = [];
 
-  SortOption sortMethod = SortOption.name;
+  SortMethod sortMethod = SortMethod.sortName;
   SortOrder sortDirection = SortOrder.ascending;
 
   @override

--- a/lib/screens/MainScreens/searchScreen.dart
+++ b/lib/screens/MainScreens/searchScreen.dart
@@ -14,6 +14,8 @@ import 'package:string_similarity/string_similarity.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:jellybook/variables.dart';
 import 'package:jellybook/widgets/roundedImageWithShadow.dart';
+import 'package:jellybook/widgets/SortByWidget.dart';
+import 'package:tentacle/tentacle.dart';
 
 class SearchScreen extends StatefulWidget {
   @override
@@ -34,6 +36,9 @@ class _SearchScreenState extends State<SearchScreen> {
   List<Entry> searchResults = [];
   // List<Map<String, dynamic>> searchResults = [];
 
+  SortOption sortMethod = SortOption.name;
+  SortOrder sortDirection = SortOrder.ascending;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -51,12 +56,29 @@ class _SearchScreenState extends State<SearchScreen> {
               controller: _searchController,
               decoration: InputDecoration(
                 prefixIcon: const Icon(Icons.search),
-                suffixIcon: IconButton(
-                  icon: const Icon(Icons.clear),
-                  onPressed: () {
-                    searchResults = [];
-                    _searchController.clear();
-                  },
+                suffixIcon: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () {
+                        searchResults = [];
+                        _searchController.clear();
+                      },
+                    ),
+                    SortByWidget(
+                      defaultSortMethod: sortMethod,
+                      defaultSortOrder: sortDirection,
+                      onChanged: (newSortMethod, newSortOrder) async {
+                        setState(() {
+                          sortMethod = newSortMethod;
+                          sortDirection = newSortOrder;
+                          getSearchResults(_searchController.text.toString());
+                        });
+                      }
+                    ),
+                  ],
                 ),
                 // only have suffix icon when the search bar is selected
                 hintText:
@@ -204,6 +226,7 @@ class _SearchScreenState extends State<SearchScreen> {
         .findAll();
 
     books = diceCoefficientRankings(searchQuery, books);
+    books.sort((Entry a, Entry b) => SortByWidget.compareEntries(a, b, sortMethod, sortDirection));
 
     // convert the results to a list of maps
     // List<Map<String, dynamic>> results = [];

--- a/lib/screens/MainScreens/searchScreen.dart
+++ b/lib/screens/MainScreens/searchScreen.dart
@@ -69,11 +69,11 @@ class _SearchScreenState extends State<SearchScreen> {
                     ),
                     SortByWidget(
                       defaultSortMethod: sortMethod,
-                      defaultSortOrder: sortDirection,
-                      onChanged: (newSortMethod, newSortOrder) async {
+                      defaultSortDirection: sortDirection,
+                      onChanged: (newSortMethod, newSortDirection) async {
                         setState(() {
                           sortMethod = newSortMethod;
-                          sortDirection = newSortOrder;
+                          sortDirection = newSortDirection;
                           getSearchResults(_searchController.text.toString());
                         });
                       }
@@ -226,7 +226,7 @@ class _SearchScreenState extends State<SearchScreen> {
         .findAll();
 
     books = diceCoefficientRankings(searchQuery, books);
-    books.sort((Entry a, Entry b) => SortByWidget.compareEntries(a, b, sortMethod, sortDirection));
+    books.sort((Entry a, Entry b) => SortFunctions.compareEntries(a, b, sortMethod, sortDirection));
 
     // convert the results to a list of maps
     // List<Map<String, dynamic>> results = [];

--- a/lib/screens/collectionScreen.dart
+++ b/lib/screens/collectionScreen.dart
@@ -51,8 +51,8 @@ class _collectionScreenState extends State<collectionScreen> {
   });
 
   final Completer _isSortPrefsLoaded = Completer();
-  SortMethod? sortMethod;
-  SortOrder? sortDirection;
+  SortMethod sortMethod = SortMethod.sortName;
+  SortOrder sortDirection = SortOrder.ascending;
 
   final isar = Isar.getInstance();
   // make a list of entries from the the list of bookIds
@@ -72,7 +72,7 @@ class _collectionScreenState extends State<collectionScreen> {
     // checkeach field of the entry to make sure it is not null
   }
 
-  Future<List<Entry>> get entries async {
+  Future<List<Entry>> resolveWaitsForBuild() async {
     await _isSortPrefsLoaded.future;
     return await getEntries();
   }
@@ -84,14 +84,14 @@ class _collectionScreenState extends State<collectionScreen> {
         title: Text(name),
         actions: <Widget>[
           SortByWidget(
-              defaultSortMethod: SortMethod.sortName,
-              defaultSortOrder: SortOrder.ascending,
-              sharedPrefsKey: "${name}CollectionScreen",
-              onChanged: (newSortMethod, newSortOrder) async {
+              defaultSortMethod: sortMethod,
+              defaultSortDirection: sortDirection,
+              sharedPrefsKey: "${folderId}CollectionScreenSort",
+              onChanged: (newSortMethod, newSortDirection) async {
                 WidgetsBinding.instance.addPostFrameCallback((_) =>
                   setState(() {
                       sortMethod = newSortMethod;
-                      sortDirection = newSortOrder;
+                      sortDirection = newSortDirection;
                       if (!_isSortPrefsLoaded.isCompleted) {
                         _isSortPrefsLoaded.complete();
                       }
@@ -102,14 +102,14 @@ class _collectionScreenState extends State<collectionScreen> {
         ],
       ),
       body: FutureBuilder(
-        future: entries,
+        future: resolveWaitsForBuild(),
         builder: (BuildContext context, AsyncSnapshot snapshot) {
           if (snapshot.hasData &&
               snapshot.data.length > 0 &&
               snapshot.connectionState == ConnectionState.done) {
             List<Entry> snapshotList = snapshot.data;
             snapshotList.sort(
-              (a, b) => SortByWidget.compareEntries(a, b, sortMethod!, sortDirection!)
+              (a, b) => SortFunctions.compareEntries(a, b, sortMethod, sortDirection)
             );
             return ListView.builder(
               itemCount: snapshotList.length,

--- a/lib/screens/collectionScreen.dart
+++ b/lib/screens/collectionScreen.dart
@@ -2,6 +2,7 @@
 
 // import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:jellybook/widgets/SortByWidget.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:isar/isar.dart';
 import 'package:isar_flutter_libs/isar_flutter_libs.dart';
@@ -15,6 +16,7 @@ import 'package:fancy_shimmer_image/fancy_shimmer_image.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:jellybook/variables.dart';
 import 'package:jellybook/widgets/roundedImageWithShadow.dart';
+import 'package:tentacle/tentacle.dart';
 
 class collectionScreen extends StatefulWidget {
   final String folderId;
@@ -47,6 +49,9 @@ class _collectionScreenState extends State<collectionScreen> {
     required this.bookIds,
   });
 
+  SortOption sortMethod = SortOption.name;
+  SortOrder sortDirection = SortOrder.ascending;
+
   final isar = Isar.getInstance();
   // make a list of entries from the the list of bookIds
   Future<List<Entry>> getEntries() async {
@@ -74,6 +79,18 @@ class _collectionScreenState extends State<collectionScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(name),
+        actions: <Widget>[
+          SortByWidget(
+              defaultSortMethod: sortMethod,
+              defaultSortOrder: sortDirection,
+              onChanged: (newSortMethod, newSortOrder) async {
+                setState(() {
+                  sortMethod = newSortMethod;
+                  sortDirection = newSortOrder;
+                });
+              }
+          )
+        ],
       ),
       body: FutureBuilder(
         future: entries,
@@ -81,34 +98,38 @@ class _collectionScreenState extends State<collectionScreen> {
           if (snapshot.hasData &&
               snapshot.data.length > 0 &&
               snapshot.connectionState == ConnectionState.done) {
+            List<Entry> snapshotList = snapshot.data;
+            snapshotList.sort(
+              (a, b) => SortByWidget.compareEntries(a, b, sortMethod, sortDirection)
+            );
             return ListView.builder(
-              itemCount: snapshot.data.length,
+              itemCount: snapshotList.length,
               itemBuilder: (BuildContext context, int index) {
                 return ListTile(
                   onTap: () async {
-                    if (snapshot.data[index].type != EntryType.folder) {
+                    if (snapshotList[index].type != EntryType.folder) {
                       var result = await Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (context) => InfoScreen(
-                            entry: snapshot.data[index],
+                            entry: snapshotList[index],
                           ),
                         ),
                       );
                       if (result != null) {
-                        snapshot.data[index].isFavorited =
-                            result.$1 ?? snapshot.data[index].isFavorited;
-                        snapshot.data[index].downloaded =
-                            result.$2 ?? snapshot.data[index].downloaded;
+                        snapshotList[index].isFavorited =
+                            result.$1 ?? snapshotList[index].isFavorited;
+                        snapshotList[index].downloaded =
+                            result.$2 ?? snapshotList[index].downloaded;
                         await isar?.writeTxn(() async {
-                          await isar?.entrys.put(snapshot.data[index]);
+                          await isar?.entrys.put(snapshotList[index]);
                         });
                       }
                     } else {
                       var folder = isar!.folders
                           .where()
                           .filter()
-                          .idEqualTo(snapshot.data[index].id)
+                          .idEqualTo(snapshotList[index].id)
                           .findFirstSync();
                       Navigator.push(
                         context,
@@ -123,15 +144,15 @@ class _collectionScreenState extends State<collectionScreen> {
                       );
                     }
                   },
-                  title: Text(snapshot.data[index].title),
+                  title: Text(snapshotList[index].title),
                   leading: RoundedImageWithShadow(
-                    imageUrl: snapshot.data[index].imagePath,
+                    imageUrl: snapshotList[index].imagePath,
                     radius: 5,
                   ),
                   subtitle: Row(
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [
-                      if (snapshot.data[index].rating >= 0)
+                      if (snapshotList[index].rating >= 0)
                         IgnorePointer(
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.start,
@@ -140,12 +161,12 @@ class _collectionScreenState extends State<collectionScreen> {
                                 padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
                                 child: CustomRating(
                                   max: 5,
-                                  score: snapshot.data[index].rating / 2,
+                                  score: snapshotList[index].rating / 2,
                                   star: Star(
                                     fillColor: Color.lerp(
                                         Colors.red,
                                         Colors.yellow,
-                                        snapshot.data[index].rating / 10)!,
+                                        snapshotList[index].rating / 10)!,
                                     emptyColor: Colors.grey.withOpacity(0.5),
                                   ),
                                   onRating: (double score) {},
@@ -154,7 +175,7 @@ class _collectionScreenState extends State<collectionScreen> {
                               Padding(
                                 padding: const EdgeInsets.fromLTRB(8, 0, 0, 0),
                                 child: Text(
-                                  "${(snapshot.data[index].rating / 2).toStringAsFixed(2)} / 5.00",
+                                  "${(snapshotList[index].rating / 2).toStringAsFixed(2)} / 5.00",
                                   style: const TextStyle(
                                     fontStyle: FontStyle.italic,
                                     fontSize: 15,
@@ -164,11 +185,11 @@ class _collectionScreenState extends State<collectionScreen> {
                             ],
                           ),
                         ),
-                      if (snapshot.data[index].rating < 0 &&
-                          snapshot.data[index].description != '')
+                      if (snapshotList[index].rating < 0 &&
+                          snapshotList[index].description != '')
                         Flexible(
                           child: MarkdownBody(
-                            data: fixRichText(snapshot.data[index].description),
+                            data: fixRichText(snapshotList[index].description),
                             extensionSet: md.ExtensionSet(
                               md.ExtensionSet.gitHubFlavored.blockSyntaxes,
                               <md.InlineSyntax>[

--- a/lib/screens/infoScreen.dart
+++ b/lib/screens/infoScreen.dart
@@ -64,6 +64,7 @@ class _InfoScreenState extends State<InfoScreen> {
   }
 
   Future<void> setRead() async {
+    if (entry.playCount < 0) {entry.playCount = 0;}
     if (entry.progress < 100) {
       entry.progress = 100;
       entry.playCount += 1;

--- a/lib/screens/infoScreen.dart
+++ b/lib/screens/infoScreen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_star/flutter_star.dart';
 import 'package:jellybook/models/login.dart';
 import 'package:jellybook/providers/deleteComic.dart';
 import 'package:jellybook/providers/fixRichText.dart';
+import 'package:jellybook/providers/updateLastPlayInfo.dart';
 import 'package:jellybook/screens/downloaderScreen.dart';
 import 'package:jellybook/screens/EditScreen.dart';
 import 'package:jellybook/screens/readingScreen.dart';
@@ -75,6 +76,7 @@ class _InfoScreenState extends State<InfoScreen> {
     await isar?.writeTxn(() async {
       await isar.entrys.put(entry);
     });
+    await updateLastPlayInfo(entry.id, entry.playCount, entry.lastPlayedDate);
   }
 
   Future<Set<Author>> getAuthors() async {

--- a/lib/screens/infoScreen.dart
+++ b/lib/screens/infoScreen.dart
@@ -65,8 +65,11 @@ class _InfoScreenState extends State<InfoScreen> {
   Future<void> setRead() async {
     if (entry.progress < 100) {
       entry.progress = 100;
+      entry.playCount += 1;
     } else {
       entry.progress = 0;
+      entry.playCount = 0;
+      entry.lastPlayedDate = '';
     }
     final isar = Isar.getInstance();
     await isar?.writeTxn(() async {

--- a/lib/screens/readingScreen.dart
+++ b/lib/screens/readingScreen.dart
@@ -3,6 +3,7 @@
 
 // import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:jellybook/providers/updateLastPlayInfo.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:isar/isar.dart';
 import 'package:isar_flutter_libs/isar_flutter_libs.dart';
@@ -152,6 +153,7 @@ class _ReadingScreenState extends State<ReadingScreen> {
       entry.lastPlayedDate = DateTime.now().toIso8601String();
       isar!.entrys.put(entry);
     });
+    await updateLastPlayInfo(id, entry.playCount, entry.lastPlayedDate);
     // get the file extension
     var fileExtension = await checkFileExtension(id);
 

--- a/lib/screens/readingScreen.dart
+++ b/lib/screens/readingScreen.dart
@@ -146,6 +146,12 @@ class _ReadingScreenState extends State<ReadingScreen> {
 
   // choose how to read the file
   Future<void> readComic(String id) async {
+    Entry entry = await isar!.entrys.filter().idEqualTo(id).findFirst() as Entry;
+    await isar!.writeTxn(() async {
+      entry.playCount += 1;
+      entry.lastPlayedDate = DateTime.now().toIso8601String();
+      isar!.entrys.put(entry);
+    });
     // get the file extension
     var fileExtension = await checkFileExtension(id);
 

--- a/lib/screens/readingScreen.dart
+++ b/lib/screens/readingScreen.dart
@@ -149,6 +149,7 @@ class _ReadingScreenState extends State<ReadingScreen> {
   Future<void> readComic(String id) async {
     Entry entry = await isar!.entrys.filter().idEqualTo(id).findFirst() as Entry;
     await isar!.writeTxn(() async {
+      if (entry.playCount < 0) {entry.playCount = 0;}
       entry.playCount += 1;
       entry.lastPlayedDate = DateTime.now().toIso8601String();
       isar!.entrys.put(entry);

--- a/lib/widgets/SortByWidget.dart
+++ b/lib/widgets/SortByWidget.dart
@@ -1,4 +1,4 @@
-// Purpose: This file contains the SortByWidget widget, which is a stateful drop-down menu used to choose how to sort books.
+// Purpose: This file contains the SortBy widget, which is a stateful drop-down menu used to choose how to sort books.
 
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -10,10 +10,10 @@ import 'package:collection/collection.dart';
 enum SortMethod {
   sortName("Name"),
   rating("Rating"),
-  //criticsRating("Critics Rating"), //mising or N/A for books
+  //criticsRating("Critics Rating"),
   dateAdded("Date Added"),
   datePlayed("Date Played"),
-  //parentalRating("Parental Rating"), //too lazy to do this
+  //parentalRating("Parental Rating"),
   playCount("Play Count"),
   releaseDate("Release Date"),
   runtime("Runtime"),
@@ -28,66 +28,19 @@ class SortByWidget extends StatefulWidget {
     super.key,
     this.child,
     required this.defaultSortMethod,
-    required this.defaultSortOrder,
+    required this.defaultSortDirection,
     this.sharedPrefsKey,
     required this.onChanged,
   });
 
   final Widget? child;
   final SortMethod defaultSortMethod;
-  final SortOrder defaultSortOrder;
+  final SortOrder defaultSortDirection;
   final String? sharedPrefsKey;
   final Future<void> Function(SortMethod sortMethod, SortOrder sortDirection) onChanged;
 
   @override
   State<SortByWidget> createState() => _SortByState();
-
-  static int compareEntries(Entry a, Entry b, SortMethod sortMethod, SortOrder sortDirection) {
-    String aString = a.sortName.toLowerCase();
-    String bString = b.sortName.toLowerCase();
-    switch (sortMethod) {
-      case SortMethod.sortName: //seriesSortName + sortName
-        aString = '${a.seriesName.toLowerCase()},$aString';
-        bString = '${b.seriesName.toLowerCase()},$bString';
-        break;
-      case SortMethod.rating: //communityRating + sortName
-        aString = '${a.rating},$aString';
-        bString = '${b.rating},$bString';
-        break;
-      case SortMethod.dateAdded: //dateCreated + sortName
-        aString = '${a.dateCreated},$aString';
-        bString = '${b.dateCreated},$bString';
-        break;
-      case SortMethod.datePlayed: //datePlayed + sortName
-        aString = '${a.lastPlayedDate},$aString';
-        bString = '${b.lastPlayedDate},$bString';
-        break;
-      case SortMethod.playCount: //playCount + sortName
-        aString = '${a.playCount},$aString';
-        bString = '${b.playCount},$bString';
-        break;
-      case SortMethod.releaseDate: //productionYear + premiereDate + sortName
-        aString = '${a.releaseDate},${a.premiereDate},$aString';
-        bString = '${b.releaseDate},${b.premiereDate},$bString';
-        break;
-      case SortMethod.runtime: //runtime + sortName
-        aString = '${a.runTimeTicks},$aString';
-        bString = '${b.runTimeTicks},$bString';
-        break;
-      case SortMethod.indexNum: //indexNumber + sortName
-        aString = '${a.indexNumber},$aString';
-        bString = '${b.indexNumber},$bString';
-        break;
-      default: //just sortName
-        break;
-    }
-
-    if (sortDirection == SortOrder.ascending) {
-      return compareNatural(aString, bString);
-    } else {
-      return compareNatural(aString, bString) * -1;
-    }
-  }
 }
 
 class _SortByState extends State<SortByWidget> {
@@ -101,7 +54,7 @@ class _SortByState extends State<SortByWidget> {
     super.initState();
     loadPrefs().then((_) {
       _sortMethod ??= widget.defaultSortMethod;
-      _sortDirection ??= widget.defaultSortOrder;
+      _sortDirection ??= widget.defaultSortDirection;
       _prefsLoaded.complete();
       widget.onChanged.call(_sortMethod!, _sortDirection!);
     });
@@ -180,5 +133,61 @@ class _SortByState extends State<SortByWidget> {
         icon: const Icon(Icons.sort),
       );}
     );
+  }
+}
+
+class SortFunctions {
+  static int compareEntries(Entry a, Entry b, SortMethod sortMethod, SortOrder sortDirection) {
+    String aString = a.sortName.toLowerCase().trim();
+    String bString = b.sortName.toLowerCase().trim();
+    if (aString == '') {
+      aString = a.title.toLowerCase().trim();
+    }
+    if (bString == '') {
+      bString = b.title.toLowerCase().trim();
+    }
+
+    switch (sortMethod) {
+      case SortMethod.sortName: //seriesSortName + sortName
+        aString = '${a.seriesName.toLowerCase()},$aString';
+        bString = '${b.seriesName.toLowerCase()},$bString';
+        break;
+      case SortMethod.rating: //communityRating + sortName
+        aString = '${a.rating},$aString';
+        bString = '${b.rating},$bString';
+        break;
+      case SortMethod.dateAdded: //dateCreated + sortName
+        aString = '${a.dateCreated},$aString';
+        bString = '${b.dateCreated},$bString';
+        break;
+      case SortMethod.datePlayed: //datePlayed + sortName
+        aString = '${a.lastPlayedDate},$aString';
+        bString = '${b.lastPlayedDate},$bString';
+        break;
+      case SortMethod.playCount: //playCount + sortName
+        aString = '${a.playCount},$aString';
+        bString = '${b.playCount},$bString';
+        break;
+      case SortMethod.releaseDate: //productionYear + premiereDate + sortName
+        aString = '${a.releaseDate},${a.premiereDate},$aString';
+        bString = '${b.releaseDate},${b.premiereDate},$bString';
+        break;
+      case SortMethod.runtime: //runtime + sortName
+        aString = '${a.runTimeTicks},$aString';
+        bString = '${b.runTimeTicks},$bString';
+        break;
+      case SortMethod.indexNum: //indexNumber + sortName
+        aString = '${a.indexNumber},$aString';
+        bString = '${b.indexNumber},$bString';
+        break;
+      default: //just sortName
+        break;
+    }
+
+    if (sortDirection == SortOrder.ascending) {
+      return compareNatural(aString, bString);
+    } else {
+      return compareNatural(aString, bString) * -1;
+    }
   }
 }

--- a/lib/widgets/SortByWidget.dart
+++ b/lib/widgets/SortByWidget.dart
@@ -1,0 +1,157 @@
+// Purpose: This file contains the SortByWidget widget, which is a stateful drop-down menu used to choose how to sort books.
+
+
+import 'package:flutter/material.dart';
+import 'package:jellybook/models/entry.dart';
+import 'package:tentacle/tentacle.dart';
+import 'package:collection/collection.dart';
+
+enum SortOption {
+  name("Name"),
+  communityRating("Community Rating"),
+  //criticsRating("Critics Rating"), //mising or N/A for books
+  dateAdded("Date Added"),
+  datePlayed("Date Played"),
+  parentalRating("Parental Rating"),
+  playCount("Play Count"),
+  releaseDate("Release Date"),
+  runtime("Runtime"),
+  indexNum("Index Number");
+
+  const SortOption(this.label);
+  final String label;
+}
+
+class SortByWidget extends StatefulWidget {
+  const SortByWidget({
+    super.key,
+    this.child,
+    required this.defaultSortMethod,
+    required this.defaultSortOrder,
+    required this.onChanged,
+  });
+
+  final Widget? child;
+  final SortOption defaultSortMethod;
+  final SortOrder defaultSortOrder;
+  final Future<void> Function(SortOption sortMethod, SortOrder sortDirection) onChanged;
+
+  @override
+  State<SortByWidget> createState() => _SortByState();
+
+  static int compareEntries(Entry a, Entry b, SortOption sortMethod, SortOrder sortDirection) {
+    String aString = a.sortName;
+    String bString = b.sortName;
+    switch (sortMethod) {
+      case SortOption.name: //seriesSortName + sortName
+        aString = '${a.seriesName},$aString';
+        bString = '${b.seriesName},$bString';
+        break;
+      case SortOption.communityRating: //communityRating + sortName
+        aString = '${a.communityRating},$aString';
+        bString = '${b.communityRating},$bString';
+        break;
+      case SortOption.dateAdded: //dateCreated + sortName
+        aString = '${a.dateCreated},$aString';
+        bString = '${b.dateCreated},$bString';
+        break;
+      case SortOption.datePlayed: //datePlayed + sortName
+        aString = '${a.lastPlayedDate},$aString';
+        bString = '${b.lastPlayedDate},$bString';
+        break;
+      case SortOption.parentalRating: //officialRating + sortName
+        aString = '${a.officialRating},$aString';
+        bString = '${b.officialRating},$bString';
+        break;
+      case SortOption.playCount: //playCount + sortName
+        aString = '${a.playCount},$aString';
+        bString = '${b.playCount},$bString';
+        break;
+      case SortOption.releaseDate: //productionYear + premiereDate + sortName
+        aString = '${a.releaseDate},${a.premiereDate},$aString';
+        bString = '${b.releaseDate},${b.premiereDate},$bString';
+        break;
+      case SortOption.runtime: //runtime + sortName
+        aString = '${a.runTimeTicks},$aString';
+        bString = '${b.runTimeTicks},$bString';
+        break;
+      case SortOption.indexNum: //indexNumber + sortName
+        aString = '${a.indexNumber},$aString';
+        bString = '${b.indexNumber},$bString';
+        break;
+      default: //just sortName
+        break;
+    }
+
+    if (sortDirection == SortOrder.ascending) {
+      return compareNatural(aString, bString);
+    } else {
+      return compareNatural(aString, bString) * -1;
+    }
+  }
+}
+
+class _SortByState extends State<SortByWidget> {
+  late SortOption _sortMethod;
+  late SortOrder _sortDirection;
+
+  @override
+  void initState() {
+    super.initState();
+    _sortMethod = widget.defaultSortMethod;
+    _sortDirection = widget.defaultSortOrder;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<SortOption>(
+      initialValue: _sortMethod,
+      onSelected: (SortOption sortMethod) {
+        SortOrder sortDirection = _sortDirection;
+        if (sortMethod == _sortMethod) {
+          if (sortDirection == SortOrder.ascending) {
+            sortDirection = SortOrder.descending;
+          } else {
+            sortDirection = SortOrder.ascending;
+          }
+        } else {
+          sortDirection = SortOrder.ascending;
+        }
+        setState(() {
+          _sortMethod = sortMethod;
+          _sortDirection = sortDirection;
+        });
+        widget.onChanged.call(_sortMethod, _sortDirection);
+      },
+      itemBuilder: (BuildContext context) {
+        List<PopupMenuItem<SortOption>> itemList = [];
+        for (SortOption option in SortOption.values) {
+          if (_sortMethod == option) {
+            IconData directionIcon;
+            if (_sortDirection == SortOrder.ascending) {
+              directionIcon = Icons.arrow_upward;
+            } else {
+              directionIcon = Icons.arrow_downward;
+            }
+            itemList.add(PopupMenuItem<SortOption>(
+                value: option,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(option.label),
+                    Icon(directionIcon),
+                  ],
+            )));
+          } else {
+            itemList.add(PopupMenuItem<SortOption>(
+                value: option,
+                child: Text(option.label),
+            ));
+          }
+        }
+        return itemList;
+      },
+      icon: const Icon(Icons.sort),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
     path: ./submodules/tentacle/
   string_similarity: ^2.0.0
   connectivity_plus: ^6.0.1
+  collection: any
 
   # Translations
   flutter_localizations:


### PR DESCRIPTION
**Changes**
- Adds SortByWidget, a stateful drop-down menu used to choose how to sort books
- Adds sort functionality to the search and collection screens
- On collection screens, sort preferences are saved
- Each Entry now collects additional data to allow for sorting analogous to Jellyfin
- Forwards the new Entry properties that respond to user action to the Jellyfin server

**Issues**
Fixes #97

**Comments**
Really helpful when a series doesn't have books with numbers in their name or that are titled alphabetically :D
(Here's an example, sorting ascending by name (default and previous behavior) vs. sorting by index number)
<img width="550" alt="image" src="https://github.com/user-attachments/assets/d7fa7e3d-b794-43da-a91f-d354771ac82f" />